### PR TITLE
DM-7332: Modernize & claen tests

### DIFF
--- a/tests/testMeasurementFramework.py
+++ b/tests/testMeasurementFramework.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
 #
 # LSST Data Management System
-# See COPYRIGHT file at the top of the source tree.
+#
+# Copyright 2008-2016  AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).
@@ -12,14 +14,13 @@
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the LSST License Statement and
-# the GNU General Public License along with this program. If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
 #
-
 import unittest
 
 import lsst.utils.tests
@@ -27,7 +28,9 @@ import lsst.meas.base.tests
 from lsst.meas.base.tests import AlgorithmTestCase
 from lsst.meas.extensions.simpleShape import SimpleShapeResultKey
 
+
 class SimpleShapeMFTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
+
     def setUp(self):
         self.bbox = lsst.afw.geom.Box2I(lsst.afw.geom.Point2I(-20, -30),
                                         lsst.afw.geom.Extent2I(240, 160))
@@ -36,26 +39,26 @@ class SimpleShapeMFTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
                                lsst.afw.geom.ellipses.Quadrupole(8, 9, 3))
 
         self.expectedKeySet = set(['ext_simpleShape_SimpleShape_IxSigma',
-                             'ext_simpleShape_SimpleShape_Ix_Iy_Cov',
-                             'ext_simpleShape_SimpleShape_IxxSigma',
-                             'ext_simpleShape_SimpleShape_Ixx_Ix_Cov',
-                             'ext_simpleShape_SimpleShape_Ixx_Ixy_Cov',
-                             'ext_simpleShape_SimpleShape_Ixx_Iy_Cov',
-                             'ext_simpleShape_SimpleShape_Ixx_Iyy_Cov',
-                             'ext_simpleShape_SimpleShape_IxySigma',
-                             'ext_simpleShape_SimpleShape_Ixy_Ix_Cov',
-                             'ext_simpleShape_SimpleShape_Ixy_Iy_Cov',
-                             'ext_simpleShape_SimpleShape_IySigma',
-                             'ext_simpleShape_SimpleShape_IyySigma',
-                             'ext_simpleShape_SimpleShape_Iyy_Ix_Cov',
-                             'ext_simpleShape_SimpleShape_Iyy_Ixy_Cov',
-                             'ext_simpleShape_SimpleShape_Iyy_Iy_Cov',
-                             'ext_simpleShape_SimpleShape_flag',
-                             'ext_simpleShape_SimpleShape_x',
-                             'ext_simpleShape_SimpleShape_xx',
-                             'ext_simpleShape_SimpleShape_xy',
-                             'ext_simpleShape_SimpleShape_y',
-                             'ext_simpleShape_SimpleShape_yy'])
+                                   'ext_simpleShape_SimpleShape_Ix_Iy_Cov',
+                                   'ext_simpleShape_SimpleShape_IxxSigma',
+                                   'ext_simpleShape_SimpleShape_Ixx_Ix_Cov',
+                                   'ext_simpleShape_SimpleShape_Ixx_Ixy_Cov',
+                                   'ext_simpleShape_SimpleShape_Ixx_Iy_Cov',
+                                   'ext_simpleShape_SimpleShape_Ixx_Iyy_Cov',
+                                   'ext_simpleShape_SimpleShape_IxySigma',
+                                   'ext_simpleShape_SimpleShape_Ixy_Ix_Cov',
+                                   'ext_simpleShape_SimpleShape_Ixy_Iy_Cov',
+                                   'ext_simpleShape_SimpleShape_IySigma',
+                                   'ext_simpleShape_SimpleShape_IyySigma',
+                                   'ext_simpleShape_SimpleShape_Iyy_Ix_Cov',
+                                   'ext_simpleShape_SimpleShape_Iyy_Ixy_Cov',
+                                   'ext_simpleShape_SimpleShape_Iyy_Iy_Cov',
+                                   'ext_simpleShape_SimpleShape_flag',
+                                   'ext_simpleShape_SimpleShape_x',
+                                   'ext_simpleShape_SimpleShape_xx',
+                                   'ext_simpleShape_SimpleShape_xy',
+                                   'ext_simpleShape_SimpleShape_y',
+                                   'ext_simpleShape_SimpleShape_yy'])
 
     def tearDown(self):
         del self.bbox
@@ -83,17 +86,13 @@ class SimpleShapeMFTestCase(AlgorithmTestCase, lsst.utils.tests.TestCase):
         for attr in ("center", "ellipse", "covariance", "getFlag"):
             self.assertTrue(hasattr(result, attr), "Result Object missing {}".format(attr))
 
-def suite():
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
     lsst.utils.tests.init()
 
-    suites = []
-    suites += unittest.makeSuite(SimpleShapeMFTestCase)
-    suites += unittest.makeSuite(lsst.utils.tests.MemoryTestCase)
-    return unittest.TestSuite(suites)
-
-def run(shouldExit=False):
-    lsst.utils.tests.run(suite(), shouldExit)
-
 if __name__ == "__main__":
-    run(True)
-            
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testSimpleShape.py
+++ b/tests/testSimpleShape.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 #
 # LSST Data Management System
-# Copyright 2008-2013 LSST Corporation.
+#
+# Copyright 2008-2016  AURA/LSST.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).
@@ -18,9 +19,8 @@
 #
 # You should have received a copy of the LSST License Statement and
 # the GNU General Public License along with this program.  If not,
-# see <http://www.lsstcorp.org/LegalNotices/>.
+# see <https://www.lsstcorp.org/LegalNotices/>.
 #
-
 import unittest
 import numpy
 
@@ -30,6 +30,7 @@ import lsst.afw.geom.ellipses as el
 import lsst.afw.image
 from lsst.meas.extensions.simpleShape import SimpleShape
 
+
 class SimpleShapeTestCase(lsst.utils.tests.TestCase):
 
     def setUp(self):
@@ -37,19 +38,19 @@ class SimpleShapeTestCase(lsst.utils.tests.TestCase):
             el.Quadrupole(25.0, 25.0, 0.0),
             el.Quadrupole(27.0, 22.0, -5.0),
             el.Quadrupole(23.0, 28.0, 2.0),
-            ]
+        ]
         self.centers = [
             lsst.afw.geom.Point2D(0.0, 0.0),
             lsst.afw.geom.Point2D(2.0, 3.0),
             lsst.afw.geom.Point2D(-1.0, 2.5),
-            ]
+        ]
         for ellipseCore in self.ellipseCores:
             ellipseCore.scale(2)
         self.bbox = lsst.afw.geom.Box2I(lsst.afw.geom.Point2I(-500, -500), lsst.afw.geom.Point2I(50, 50))
         self.xg, self.yg = numpy.meshgrid(
             numpy.arange(self.bbox.getBeginX(), self.bbox.getEndX(), dtype=float),
             numpy.arange(self.bbox.getBeginY(), self.bbox.getEndY(), dtype=float)
-            )
+        )
 
     def evaluateGaussian(self, ellipse):
         '''
@@ -68,7 +69,7 @@ class SimpleShapeTestCase(lsst.utils.tests.TestCase):
         '''
         dEllipse = el.Ellipse(dEllipseCore, dCenter)
         image = lsst.afw.image.MaskedImageF(self.bbox)
-        image.getImage().getArray()[:,:] = self.evaluateGaussian(dEllipse)
+        image.getImage().getArray()[:, :] = self.evaluateGaussian(dEllipse)
         wEllipse = el.Ellipse(wEllipseCore, wCenter)
         result = SimpleShape.computeMoments(wEllipse, image)
         return result
@@ -76,7 +77,7 @@ class SimpleShapeTestCase(lsst.utils.tests.TestCase):
     def testCorrectWeightedMoments(self):
         '''
         Test that the measured moments can be corrected for the fact that the measurement
-        contains information on the moments of the weight function used to make the 
+        contains information on the moments of the weight function used to make the
         measurement. The results should only contain the objects shape and not the moments
         used to make the measurement. This is a subset of the functionality in testNoNoiseGaussians.
         Because the other test tests a broader scope, it is useful to have this test happen under
@@ -118,19 +119,13 @@ class SimpleShapeTestCase(lsst.utils.tests.TestCase):
                                  numpy.array(center),
                                  rtol=1E-8, atol=1E-15)
 
-def suite():
-    """Returns a suite containing all the test cases in this module."""
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
 
+
+def setup_module(module):
     lsst.utils.tests.init()
 
-    suites = []
-    suites += unittest.makeSuite(SimpleShapeTestCase)
-    suites += unittest.makeSuite(lsst.utils.tests.MemoryTestCase)
-    return unittest.TestSuite(suites)
-
-def run(shouldExit=False):
-    """Run the tests"""
-    lsst.utils.tests.run(suite(), shouldExit)
-
 if __name__ == "__main__":
-    run(True)
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
The tests have been modernized to make them runnable under the py.test
framework. They have been autoformatted using autopep8 to make them
compliant with the LSST PEP8 guidelines. All depracated asserts have
been replaced with the modern equivalents.
