### PR TITLE
DM-30015: Update Sphinx conf.py for documenteer 0.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
-===============================
-``meas_extensions_simpleShape``
-===============================
+###########################
+meas_extensions_simpleShape
+###########################
 
-Extension which measures second moments with a circular Gaussian weighting, where the Gaussian is
-pre-defined. Additionally useful as an example for creating c++ measurement plugins.
+``meas_extensions_simpleShape`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
+
+The ``lsst.meas.extensions.simpleShape`` module provides a measurement extension that measures second moments with a circular Gaussian weighting, where the Gaussian is
+pre-defined.
+This module is also useful as an example for creating C++ measurement plugins.
+Documentation is available at https://pipelines.lsst.io/modules/lsst.meas.extensions.simpleShape/index.html.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,13 +1,13 @@
 """Sphinx configuration file for an LSST stack package.
-
-This configuration only affects single-package Sphinx documenation builds.
+This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.meas.extensions.simpleShape
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='meas_extensions_simpleShape',
-    version=lsst.meas.extensions.simpleShape.version.__version__))
+project = "meas_extensions_simpleShape"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,12 @@
 [flake8]
 max-line-length = 110
 ignore = E133, E226, E228, N802, N803, N806, W503
-exclude = __init__.py
+exclude =
+  bin,
+  doc/conf.py,
+  **/*/__init__.py,
+  **/*/version.py,
+  tests/.tests
 
 [tool:pytest]
 addopts = --flake8


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package)

- Add a basic README
- Update doc/conf.py for the documenteer 0.6 Sphinx configuration API
- Update flake8 exclusions in setup.cfg